### PR TITLE
Use custom drag layer as preview UI for all cases

### DIFF
--- a/app/components/TripIdeaPanel.js
+++ b/app/components/TripIdeaPanel.js
@@ -48,9 +48,9 @@ class TripIdeaPanel extends Component {
 
 TripIdeaPanel.propTypes = {
   connectDropTarget: PropTypes.func,
-  hover: PropTypes.bool.isRequired,
+  hover: PropTypes.bool,
   idea: PropTypes.object,
-  onFocusIdea: PropTypes.func.isRequired
+  onFocusIdea: PropTypes.func
 };
 
 const styles = {

--- a/app/components/TripIdeaUI.js
+++ b/app/components/TripIdeaUI.js
@@ -8,7 +8,7 @@ import { DragSource, DropTarget } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { compose } from 'redux';
 import TripIdeaPanel from './TripIdeaPanel';
-import { dndTypes, isMobile } from 'app/constants';
+import { dndTypes } from 'app/constants';
 
 /*
  * React-dnd drag source
@@ -68,9 +68,19 @@ function ideaTargetCollect(connect) {
 }
 
 class TripIdeaUI extends Component {
+  componentDidMount() {
+    /*
+     * Set an empty image as drag preview so that the user only sees the
+     * custom drag layer
+     */
+    this.props.connectDragPreview(getEmptyImage(), {
+      // IE fallback
+      captureDraggingState: true
+    });
+  }
+
   render() {
     const {
-      connectDragPreview,
       connectDragSource,
       connectDropTarget,
       idea,
@@ -124,11 +134,6 @@ class TripIdeaUI extends Component {
       );
     } else {
       fullSection = connectDragSource(ideaPanel);
-    }
-
-    // Only connect the drag preview if the touch backend is used
-    if (isMobile) {
-      fullSection = connectDragPreview(fullSection);
     }
 
     return fullSection;

--- a/app/components/TripIdeasList.js
+++ b/app/components/TripIdeasList.js
@@ -7,7 +7,7 @@ import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 import { Button } from 'react-bootstrap';
 
-import { colors, isMobile } from 'app/constants';
+import { colors } from 'app/constants';
 import TripIdeaDragPreview from './TripIdeaDragPreview';
 import TextInput from './TextInput';
 import TripIdea from 'app/containers/TripIdea';
@@ -69,7 +69,7 @@ class TripIdeasList extends Component {
         </div>
         <div>
           {tripIdeas}
-          {isMobile && dragPreview}
+          {dragPreview}
         </div>
       </div>
     );


### PR DESCRIPTION
Previously we still used the screenshot method for desktop devices, but
it inelegantly snapped part of the Close button for each idea's UI.
Instead we'll use the custom drag layer for all platforms now.
[Finishes #131950285]
